### PR TITLE
Export Sales report in CSV Format

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "remotePath": "",
+      "port": 2345,
+      "host": "127.0.0.1",
+      "program": "${workspaceRoot}",
+      "env": {},
+      "args": [],
+      "showLog": true
+    }
+  ]
+}

--- a/api/itemReport.go
+++ b/api/itemReport.go
@@ -38,7 +38,7 @@ type report struct {
 // ExportItemReport exports Nilai Barang in CSV format
 func ExportItemReport(c *gin.Context) {
 	// Make a get request
-	rs, err := http.Get(BASE_URL + "/nilaibarang")
+	rs, err := http.Get(BaseURL + "/nilaibarang")
 
 	// Process response
 	if err != nil {

--- a/api/itemReport.go
+++ b/api/itemReport.go
@@ -38,7 +38,7 @@ type report struct {
 // ExportItemReport exports Nilai Barang in CSV format
 func ExportItemReport(c *gin.Context) {
 	// Make a get request
-	rs, err := http.Get("http://0.0.0.0:3000/api/nilaibarang")
+	rs, err := http.Get(BASE_URL + "/nilaibarang")
 
 	// Process response
 	if err != nil {

--- a/api/salesReport.go
+++ b/api/salesReport.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"golang.org/x/text/message"
@@ -57,7 +58,7 @@ func ExportSalesReport(c *gin.Context) {
 	}
 
 	// Construct URL
-	url := BASE_URL + "/penjualan?startdate=" +
+	url := BaseURL + "/penjualan?startdate=" +
 		startdate + "&enddate=" + enddate
 
 	// Make a get request
@@ -125,7 +126,7 @@ func ExportSalesReport(c *gin.Context) {
 	for _, value := range result.Items {
 		var record []string
 		record = append(record, value.OrderID)
-		record = append(record, value.TimeStamp)
+		record = append(record, convertDate(value.TimeStamp))
 		record = append(record, value.SKU)
 		record = append(record, value.Name)
 		record = append(record, strconv.Itoa(value.Amount))
@@ -154,4 +155,9 @@ func validateParams(c *gin.Context, param string, msg string) bool {
 		return false
 	}
 	return true
+}
+
+func convertDate(timeStamp string) string {
+	dt, _ := time.Parse("2006-01-02T15:04:05Z", timeStamp)
+	return dt.Format("2006-01-02 15:04:05")
 }

--- a/api/salesReport.go
+++ b/api/salesReport.go
@@ -1,0 +1,157 @@
+package api
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"math"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/text/message"
+)
+
+type transactionReport struct {
+	OrderID   string  `json:"orderid"`
+	TimeStamp string  `json:"timestamp"`
+	SKU       string  `json:"sku"`
+	Name      string  `json:"name"`
+	Amount    int     `json:"amount"`
+	Price     float64 `json:"price"`
+	Purchase  float64 `json:"purchase"`
+	Omzet     float64 `json:"omzet"`  // Amount * Price
+	Profit    float64 `json:"profit"` // Omzet - Harga Beli * Jumlah
+}
+
+type salesSummary struct {
+	PrintDate   string  `json:"printdate"`
+	StartDate   string  `json:"startdate"`
+	EndDate     string  `json:"enddate"`
+	TotalSales  int     `json:"totalsales"`
+	TotalAmount int     `json:"totalamount"`
+	TotalOmzet  float64 `json:"totalomzet"`
+	TotalProfit float64 `json:"totalprofit"`
+}
+
+type salesReport struct {
+	Items   []transactionReport `json:"items"`
+	Summary salesSummary        `json:"summary"`
+}
+
+// ExportSalesReport exports Laporan Penjualan in CSV format
+func ExportSalesReport(c *gin.Context) {
+	// Get params
+	startdate := c.Query("startdate")
+	enddate := c.Query("enddate")
+
+	// Validate
+	if !validateParams(c, startdate, "startdate") {
+		return
+	}
+	if !validateParams(c, enddate, "enddate") {
+		return
+	}
+
+	// Construct URL
+	url := BASE_URL + "/penjualan?startdate=" +
+		startdate + "&enddate=" + enddate
+
+	// Make a get request
+	rs, err := http.Get(url)
+
+	// Process response
+	if err != nil {
+		panic(err)
+	}
+	defer rs.Body.Close()
+
+	bodyBytes, err := ioutil.ReadAll(rs.Body)
+	if err != nil {
+		panic(err)
+	}
+
+	bodyString := string(bodyBytes)
+
+	if rs.StatusCode != http.StatusOK {
+		c.JSON(rs.StatusCode, gin.H{
+			"message": bodyString,
+		})
+		return
+	}
+
+	fmt.Println(bodyString)
+
+	var result salesReport
+	json.Unmarshal([]byte(bodyString), &result)
+
+	b := &bytes.Buffer{}
+	W = csv.NewWriter(b)
+
+	// Summary
+	WriteCSV(9, []string{"LAPORAN PENJUALAN"})
+	WriteCSV(9, []string{})
+	WriteCSV(9, []string{"Tanggal Cetak", result.Summary.PrintDate})
+	WriteCSV(9, []string{
+		"Tanggal", result.Summary.StartDate + " - " + result.Summary.EndDate,
+	})
+	p := message.NewPrinter(message.MatchLanguage("en"))
+	WriteCSV(9, []string{
+		"Total Omzet",
+		"Rp" + p.Sprint(int(math.Round(result.Summary.TotalOmzet))),
+	})
+	WriteCSV(9, []string{
+		"Laba Kotor",
+		"Rp" + p.Sprint(int(math.Round(result.Summary.TotalProfit))),
+	})
+	WriteCSV(9, []string{
+		"Penjualan", strconv.Itoa(result.Summary.TotalSales),
+	})
+	WriteCSV(9, []string{
+		"Total Barang", strconv.Itoa(result.Summary.TotalAmount),
+	})
+	WriteCSV(9, []string{})
+
+	// Header
+	WriteCSV(9, []string{
+		"ID Pesanan", "Waktu", "SKU", "Nama Barang", "Jumlah",
+		"Harga Jual", "Total", "Harga Beli", "Laba",
+	})
+
+	// Content
+	for _, value := range result.Items {
+		var record []string
+		record = append(record, value.OrderID)
+		record = append(record, value.TimeStamp)
+		record = append(record, value.SKU)
+		record = append(record, value.Name)
+		record = append(record, strconv.Itoa(value.Amount))
+		record = append(record, strconv.Itoa(int(math.Round(value.Price))))
+		record = append(record, strconv.Itoa(int(math.Round(value.Omzet))))
+		record = append(record, strconv.Itoa(int(math.Round(value.Purchase))))
+		record = append(record, strconv.Itoa(int(math.Round(value.Profit))))
+		WriteCSV(9, record)
+	}
+
+	W.Flush()
+	if err := W.Error(); err != nil {
+		log.Fatal(err)
+	}
+
+	c.Header("Content-Description", "Laporan Penjualan")
+	c.Header("Content-Disposition", "attachment; filename=penjualan.csv")
+	c.Data(http.StatusOK, "text/csv", b.Bytes())
+}
+
+func validateParams(c *gin.Context, param string, msg string) bool {
+	if len(param) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "Missing " + msg + " params",
+		})
+		return false
+	}
+	return true
+}

--- a/api/utils.go
+++ b/api/utils.go
@@ -5,6 +5,9 @@ import (
 	"log"
 )
 
+// BASE_URL requests to other microservice
+const BASE_URL = "http://0.0.0.0:3000/api"
+
 // W writer to produce CSV
 var W *csv.Writer
 

--- a/api/utils.go
+++ b/api/utils.go
@@ -5,8 +5,8 @@ import (
 	"log"
 )
 
-// BASE_URL requests to other microservice
-const BASE_URL = "http://0.0.0.0:3000/api"
+// BaseURL requests to other microservice
+const BaseURL = "http://0.0.0.0:3000/api"
 
 // W writer to produce CSV
 var W *csv.Writer

--- a/main.go
+++ b/main.go
@@ -9,5 +9,6 @@ import (
 func main() {
 	r := gin.Default()
 	r.GET("/nilaibarang", api.ExportItemReport)
+	r.GET("/penjualan", api.ExportSalesReport)
 	r.Run() // Listen and serve on 0.0.0.0:8080
 }


### PR DESCRIPTION
Add new endpoint to generate Sales report in CSV format. It required `startdate` and `enddate` in `YYYY-MM-DD` format.

`http://0.0.0.0:8080/penjualan?startdate=2017-12-01&enddate=2017-12-31`

Response:

![image](https://user-images.githubusercontent.com/17120764/37024037-60b21a4a-215a-11e8-9fe4-12cffd0dd16c.png)

For the default, `Harga` is in integer format. If you want to put `Rp` in front of it, add `rupiah=true` on the request.

![image](https://user-images.githubusercontent.com/17120764/37024146-a73bd58c-215a-11e8-960a-5ca46e0a62b7.png)

Another optional parameter is `prettifydate`. In Toko Ijah alternate universe, there is no timezone. So it just remove `T` and `Z` from the `timestamp`.

`http://0.0.0.0:8080/penjualan?startdate=2017-12-01&enddate=2017-12-01&prettifydate=true`

<img src="https://user-images.githubusercontent.com/17120764/37024304-02ed24a8-215b-11e8-829d-9b3f7cc153f7.png" width="350" />